### PR TITLE
(SP: 3) [Frontend][Feature] Global search dropdown, custom selects, AppHeader with theme toggle

### DIFF
--- a/backend/src/controllers/taskController.ts
+++ b/backend/src/controllers/taskController.ts
@@ -8,18 +8,20 @@ const GUEST_USER_ID = 'guest-user-id';
 
 export const getTasks = async (req: Request, res: Response) => {
   const month = req.query.month as string | undefined;
-  if (!month) throw new HttpError(400, 'month query parameter is required');
+  const where: { userId: string; date?: { startsWith: string } } = {
+    userId: GUEST_USER_ID,
+  };
 
-  const result = monthQuerySchema.safeParse(month);
-  if (!result.success) {
-    throw new HttpError(400, 'month must be in YYYY-MM format');
+  if (month) {
+    const result = monthQuerySchema.safeParse(month);
+    if (!result.success) {
+      throw new HttpError(400, 'month must be in YYYY-MM format');
+    }
+    where.date = { startsWith: `${month}-` };
   }
 
   const tasks = await prisma.task.findMany({
-    where: {
-      userId: GUEST_USER_ID,
-      date: { startsWith: `${month}-` },
-    },
+    where,
     orderBy: [{ date: 'asc' }, { order: 'asc' }],
   });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Calendar</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28" fill="none">
+  <rect x="2" y="4" width="24" height="22" rx="4" fill="#007AFF" />
+  <rect x="2" y="4" width="24" height="6" rx="4" fill="#5AC8FA" />
+  <circle cx="8" cy="7" r="1.5" fill="#ffffff" opacity="0.9" />
+  <circle cx="20" cy="7" r="1.5" fill="#ffffff" opacity="0.9" />
+  <rect x="6" y="14" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.9" />
+  <rect x="12" y="14" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.9" />
+  <rect x="18" y="14" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.9" />
+  <rect x="6" y="19" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.9" />
+  <rect x="12" y="19" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.9" />
+  <rect x="18" y="19" width="4" height="3" rx="0.5" fill="#ffffff" opacity="0.6" />
+</svg>
+

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,4 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>Frontend coming soon</body>
-</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useCallback, useState } from 'react';
 
+import { AppHeader } from './components/AppHeader';
 import { Calendar } from './components/Calendar/Calendar';
 import { useCountries } from './hooks/useCountries';
 import { GlobalStyles } from './styles/GlobalStyles';
@@ -22,14 +23,9 @@ export const App = () => {
   return (
     <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
       <GlobalStyles />
+      <AppHeader isDark={isDark} onToggleTheme={toggleTheme} />
       <Container>
-        <Calendar
-          isDark={isDark}
-          onToggleTheme={toggleTheme}
-          countries={countries}
-          country={country}
-          onCountryChange={setCountry}
-        />
+        <Calendar countries={countries} country={country} onCountryChange={setCountry} />
       </Container>
     </ThemeProvider>
   );

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+import { Moon, Sun } from 'lucide-react';
+
+interface AppHeaderProps {
+  isDark: boolean;
+  onToggleTheme: () => void;
+}
+
+const Header = styled.header`
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  background: ${({ theme }) =>
+    theme.colors.background === '#121212' ? 'rgba(18, 18, 18, 0.72)' : 'rgba(251, 251, 253, 0.72)'};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+const Inner = styled.div`
+  max-width: 1400px;
+  margin: 0 auto;
+  height: 52px;
+  padding: 0 ${({ theme }) => theme.spacing.lg};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Brand = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Logo = styled.img`
+  width: 28px;
+  height: 28px;
+  display: block;
+`;
+
+const BrandText = styled.span`
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Right = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+`;
+
+const SignInButton = styled.button`
+  border: none;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  background: ${({ theme }) => theme.colors.accent};
+  line-height: 1.2;
+  cursor: default;
+`;
+
+const ThemeButton = styled.button`
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ theme }) => theme.colors.background};
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  border-radius: 10px;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  cursor: pointer;
+  font-size: 16px;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.colors.accent};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
+    outline: none;
+  }
+`;
+
+export function AppHeader({ isDark, onToggleTheme }: AppHeaderProps) {
+  return (
+    <Header>
+      <Inner>
+        <Brand>
+          <Logo src="/favicon.svg" alt="My Calendar logo" />
+          <BrandText>My Calendar</BrandText>
+        </Brand>
+
+        <Right>
+          <SignInButton type="button" aria-label="Sign in">
+            Sign In
+          </SignInButton>
+          <ThemeButton onClick={onToggleTheme} aria-label="Toggle theme">
+            {isDark ? <Sun size={16} /> : <Moon size={16} />}
+          </ThemeButton>
+        </Right>
+      </Inner>
+    </Header>
+  );
+}

--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import {
   closestCenter,
   DndContext,
   DragEndEvent,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
 } from '@dnd-kit/core';
@@ -18,7 +19,7 @@ import { useAppDispatch, useAppSelector } from '../../store';
 import {
   createTask,
   deleteTask,
-  fetchTasks,
+  fetchTasksByMonthYear,
   optimisticReorder,
   reorderTasks,
   updateTask,
@@ -31,8 +32,6 @@ import { EditTaskModal } from './EditTaskModal';
 import { TaskCard } from './TaskCard';
 
 interface CalendarProps {
-  isDark: boolean;
-  onToggleTheme: () => void;
   countries: Country[];
   country: string;
   onCountryChange: (code: string) => void;
@@ -41,15 +40,22 @@ interface CalendarProps {
 const Wrapper = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: 12px;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
   background: ${({ theme }) => theme.colors.surface};
 `;
 
-const Grid = styled.div`
+const WeekdaysGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  grid-template-rows: auto;
-  grid-auto-rows: minmax(120px, 1fr);
+  grid-template-columns: repeat(7, minmax(180px, 1fr));
+  min-width: 1260px;
+`;
+
+const DaysGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, minmax(180px, 1fr));
+  grid-auto-rows: 260px;
+  min-width: 1260px;
 `;
 
 const WeekdayCell = styled.div`
@@ -74,21 +80,17 @@ const WEEKDAYS = Array.from({ length: 7 }, (_, i) => formatter.format(new Date(2
 
 const todayKey = formatDateKey(new Date());
 
-export function Calendar({
-  isDark,
-  onToggleTheme,
-  countries,
-  country,
-  onCountryChange,
-}: CalendarProps) {
-  const { grid, currentMonth, currentYear } = useCalendar();
+export function Calendar({ countries, country, onCountryChange }: CalendarProps) {
+  const { grid, currentMonth, currentYear, setCalendarMonth, setCalendarYear } = useCalendar();
+  const [dropPreview, setDropPreview] = useState<{ dateKey: string; index: number } | null>(null);
   const holidays = useHolidays(currentYear, country);
   const tasks = useAppSelector(state => state.tasks.tasks);
+
   const dispatch = useAppDispatch();
 
   useEffect(() => {
     const month = `${currentYear}-${String(currentMonth + 1).padStart(2, '0')}`;
-    dispatch(fetchTasks(month));
+    dispatch(fetchTasksByMonthYear(month));
   }, [dispatch, currentYear, currentMonth]);
 
   const tasksByDate = useMemo(() => {
@@ -156,6 +158,7 @@ export function Calendar({
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      setDropPreview(null);
       setActiveTask(null);
       const { active, over } = event;
       if (!over || active.id === over.id) return;
@@ -223,25 +226,78 @@ export function Calendar({
     [tasks, dispatch]
   );
 
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over) {
+        setDropPreview(null);
+        return;
+      }
+
+      const activeId = String(active.id);
+      const overId = String(over.id);
+
+      const draggedTask = tasks.find(t => t.id === activeId);
+      if (!draggedTask) {
+        setDropPreview(null);
+        return;
+      }
+
+      const overTask = tasks.find(t => t.id === overId);
+      const targetDate = overTask
+        ? overTask.date
+        : overId.startsWith('droppable-')
+          ? overId.replace('droppable-', '')
+          : overId;
+
+      const targetTasks = tasks
+        .filter(t => t.date === targetDate)
+        .sort((a, b) => a.order - b.order);
+
+      const index = overTask ? targetTasks.findIndex(t => t.id === overId) : targetTasks.length;
+
+      setDropPreview({ dateKey: targetDate, index: Math.max(0, index) });
+    },
+    [tasks]
+  );
+
+  const handleDragCancel = useCallback(() => {
+    setDropPreview(null);
+    setActiveTask(null);
+  }, []);
+
+  const handleSelectSearchResult = useCallback(
+    (task: Task) => {
+      const year = parseInt(task.date.slice(0, 4));
+      const month = parseInt(task.date.slice(5, 7)) - 1;
+      setCalendarMonth(month);
+      setCalendarYear(year);
+    },
+    [setCalendarMonth, setCalendarYear]
+  );
+
   return (
     <>
       <CalendarHeader
-        isDark={isDark}
-        onToggleTheme={onToggleTheme}
         countries={countries}
         country={country}
         onCountryChange={onCountryChange}
+        onSelectSearchResult={handleSelectSearchResult}
       />
       <DndContext
         collisionDetection={closestCenter}
         onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
       >
         <Wrapper>
-          <Grid>
+          <WeekdaysGrid>
             {WEEKDAYS.map(day => (
               <WeekdayCell key={day}>{day}</WeekdayCell>
             ))}
+          </WeekdaysGrid>
+          <DaysGrid>
             {grid.map(week =>
               week.map(date => {
                 const key = formatDateKey(date);
@@ -259,14 +315,17 @@ export function Calendar({
                     onAddTask={handleAddTask}
                     onEdit={handleEdit}
                     onDelete={handleDelete}
+                    dropPreviewIndex={dropPreview?.dateKey === key ? dropPreview.index : null}
                   />
                 );
               })
             )}
-          </Grid>
+          </DaysGrid>
         </Wrapper>
         <DragOverlay>
-          {activeTask ? <TaskCard task={activeTask} onEdit={() => {}} onDelete={() => {}} /> : null}
+          {activeTask ? (
+            <TaskCard task={activeTask} onEdit={() => {}} onDelete={() => {}} forceDraggingCursor />
+          ) : null}
         </DragOverlay>
       </DndContext>
       {editingState && (

--- a/frontend/src/components/Calendar/CalendarHeader.tsx
+++ b/frontend/src/components/Calendar/CalendarHeader.tsx
@@ -1,18 +1,21 @@
+import type { Task } from '@calendar/shared';
 import styled from '@emotion/styled';
-import { ChevronLeft, ChevronRight, Moon, Sun } from 'lucide-react';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useCalendar } from '../../hooks/useCalendar';
 import type { Country } from '../../services/holidayService';
-import { useAppDispatch } from '../../store';
+import { useAppDispatch, useAppSelector } from '../../store';
 import { setQuery } from '../../store/searchSlice';
+import { fetchAllTasks, selectFilteredTasks } from '../../store/tasksSlice';
+import { CustomSelect } from '../ui/CustomSelect';
+import { SearchResults } from './SearchResults';
 
 interface CalendarHeaderProps {
-  isDark: boolean;
-  onToggleTheme: () => void;
   countries: Country[];
   country: string;
   onCountryChange: (code: string) => void;
+  onSelectSearchResult: (task: Task) => void;
 }
 
 const Header = styled.header`
@@ -48,7 +51,11 @@ const NavButton = styled.button`
   color: ${({ theme }) => theme.colors.textSecondary};
   cursor: pointer;
   font-size: 18px;
-  transition: all 0.15s ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 
   &:hover {
     background: ${({ theme }) => theme.colors.surfaceHover};
@@ -61,79 +68,8 @@ const NavButton = styled.button`
   }
 `;
 
-const MonthSelect = styled.select`
-  font-size: 22px;
-  font-weight: 600;
-  background: ${({ theme }) => theme.colors.background};
-  border: 1px solid transparent;
-  border-radius: 10px;
-  color: ${({ theme }) => theme.colors.text};
-  cursor: pointer;
-  outline: none;
-  padding: 6px 12px;
-  letter-spacing: -0.02em;
-  transition: all 0.15s ease;
-
-  &:focus-visible {
-    border-color: ${({ theme }) => theme.colors.accent};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
-    outline: none;
-  }
-
-  option {
-    background: ${({ theme }) => theme.colors.background};
-    color: ${({ theme }) => theme.colors.text};
-    font-size: 14px;
-    font-weight: 400;
-  }
-`;
-
-const YearSelect = styled.select`
-  font-size: 22px;
-  font-weight: 600;
-  background: ${({ theme }) => theme.colors.background};
-  border: 1px solid transparent;
-  border-radius: 10px;
-  color: ${({ theme }) => theme.colors.text};
-  cursor: pointer;
-  outline: none;
-  padding: 6px 12px;
-  transition: all 0.15s ease;
-
-  &:focus-visible {
-    border-color: ${({ theme }) => theme.colors.accent};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
-    outline: none;
-  }
-
-  option {
-    background: ${({ theme }) => theme.colors.background};
-    color: ${({ theme }) => theme.colors.text};
-    font-size: 14px;
-    font-weight: 400;
-  }
-`;
-
-const CountrySelect = styled.select`
-  padding: 10px 14px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.borderLight};
-  background: ${({ theme }) => theme.colors.background};
-  color: ${({ theme }) => theme.colors.text};
-  font-size: ${({ theme }) => theme.font.size.md};
-  cursor: pointer;
-  outline: none;
-  transition: all 0.15s ease;
-
-  &:focus-visible {
-    border-color: ${({ theme }) => theme.colors.accent};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
-    outline: none;
-  }
-`;
-
 const SearchInput = styled.input`
-  padding: 10px 14px;
+  padding: 10px 32px 10px 14px;
   border-radius: 10px;
   border: 1px solid ${({ theme }) => theme.colors.borderLight};
   background: ${({ theme }) => theme.colors.background};
@@ -141,7 +77,11 @@ const SearchInput = styled.input`
   font-size: ${({ theme }) => theme.font.size.md};
   width: 220px;
   outline: none;
-  transition: all 0.15s ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.textSecondary};
@@ -153,28 +93,37 @@ const SearchInput = styled.input`
   }
 `;
 
-const ThemeButton = styled.button`
-  width: 36px;
-  height: 36px;
+const SearchWrapper = styled.div`
+  position: relative;
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+`;
+
+const ClearButton = styled.button`
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: ${({ theme }) => theme.colors.background};
-  border: 1px solid ${({ theme }) => theme.colors.borderLight};
-  border-radius: 10px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.surfaceHover};
   color: ${({ theme }) => theme.colors.textSecondary};
   cursor: pointer;
-  font-size: 16px;
-  transition: all 0.15s ease;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
 
   &:hover {
-    background: ${({ theme }) => theme.colors.surfaceHover};
-  }
-
-  &:focus-visible {
-    border-color: ${({ theme }) => theme.colors.accent};
-    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
-    outline: none;
+    background: ${({ theme }) => theme.colors.borderLight};
+    color: ${({ theme }) => theme.colors.text};
   }
 `;
 
@@ -182,11 +131,10 @@ const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'long' });
 const MONTHS = Array.from({ length: 12 }, (_, i) => monthFormatter.format(new Date(2024, i)));
 
 export function CalendarHeader({
-  isDark,
-  onToggleTheme,
   countries,
   country,
   onCountryChange,
+  onSelectSearchResult,
 }: CalendarHeaderProps) {
   const dispatch = useAppDispatch();
   const {
@@ -198,15 +146,42 @@ export function CalendarHeader({
     setCalendarYear,
   } = useCalendar();
 
+  const yearRange = Array.from({ length: 21 }, (_, i) => currentYear - 10 + i);
+
+  const monthOptions = MONTHS.map((label, value) => ({ value, label }));
+  const yearOptions = yearRange.map(y => ({ value: y, label: String(y) }));
+  const countryOptions = countries.map(c => ({ value: c.countryCode, label: c.name }));
+
   const [searchValue, setSearchValue] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const allFetchedRef = useRef(false);
 
-  const yearRange = Array.from({ length: 21 }, (_, i) => currentYear - 10 + i);
+  const filteredTasks = useAppSelector(state => selectFilteredTasks(state, searchValue));
+
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  // Reset highlighted index when search value changes
+  useEffect(() => {
+    setHighlightedIndex(-1);
+    setSelectedTaskId(null);
+  }, [searchValue]);
+
+  const isDropdownOpen = searchValue.trim() !== '';
 
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       setSearchValue(value);
+
+      if (value.trim() && !allFetchedRef.current) {
+        dispatch(fetchAllTasks());
+        allFetchedRef.current = true;
+      }
+
+      if (!value.trim()) {
+        allFetchedRef.current = false;
+      }
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
@@ -216,22 +191,47 @@ export function CalendarHeader({
     [dispatch]
   );
 
+  const handleResultSelect = useCallback(
+    (task: Task) => {
+      setSelectedTaskId(task.id);
+      onSelectSearchResult(task);
+    },
+    [onSelectSearchResult]
+  );
+
+  const handleClear = useCallback(() => {
+    setSearchValue('');
+    dispatch(setQuery(''));
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    allFetchedRef.current = false;
+    setSelectedTaskId(null);
+    setHighlightedIndex(-1);
+  }, [dispatch]);
+
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Escape') {
         setSearchValue('');
         dispatch(setQuery(''));
         if (debounceRef.current) clearTimeout(debounceRef.current);
+        return;
+      }
+
+      if (!isDropdownOpen) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHighlightedIndex(prev => Math.min(prev + 1, filteredTasks.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHighlightedIndex(prev => Math.max(prev - 1, 0));
+      } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+        e.preventDefault();
+        handleResultSelect(filteredTasks[highlightedIndex]);
       }
     },
-    [dispatch]
+    [dispatch, isDropdownOpen, filteredTasks, highlightedIndex, handleResultSelect]
   );
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
 
   return (
     <Header>
@@ -239,60 +239,69 @@ export function CalendarHeader({
         <NavButton onClick={goToPrevMonth} aria-label="Previous month">
           <ChevronLeft size={18} />
         </NavButton>
-        <MonthSelect
+        <CustomSelect
           value={currentMonth}
-          onChange={e => setCalendarMonth(Number(e.target.value))}
-          aria-label="Select month"
-        >
-          {MONTHS.map((name, i) => (
-            <option key={name} value={i}>
-              {name}
-            </option>
-          ))}
-        </MonthSelect>
-
-        <YearSelect
+          options={monthOptions}
+          onChange={setCalendarMonth}
+          ariaLabel="Select month"
+          size="lg"
+          minWidth="130px"
+          borderMode="transparent"
+        />
+        <CustomSelect
           value={currentYear}
-          onChange={e => setCalendarYear(Number(e.target.value))}
-          aria-label="Select year"
-        >
-          {yearRange.map(y => (
-            <option key={y} value={y}>
-              {y}
-            </option>
-          ))}
-        </YearSelect>
-
+          options={yearOptions}
+          onChange={setCalendarYear}
+          ariaLabel="Select year"
+          size="lg"
+          minWidth="110px"
+          borderMode="transparent"
+        />
         <NavButton onClick={goToNextMonth} aria-label="Next month">
           <ChevronRight size={18} />
         </NavButton>
       </NavGroup>
 
       <ControlsGroup>
-        <CountrySelect
+        <CustomSelect
           value={country}
-          onChange={e => onCountryChange(e.target.value)}
-          aria-label="Select country"
-        >
-          {countries.map(c => (
-            <option key={c.countryCode} value={c.countryCode}>
-              {c.name}
-            </option>
-          ))}
-        </CountrySelect>
-
-        <SearchInput
-          type="text"
-          placeholder="Search tasks..."
-          value={searchValue}
-          onChange={handleSearchChange}
-          onKeyDown={handleSearchKeyDown}
-          aria-label="Search tasks"
+          options={countryOptions}
+          onChange={onCountryChange}
+          ariaLabel="Select country"
+          size="md"
+          minWidth="220px"
+          borderMode="light"
         />
-
-        <ThemeButton onClick={onToggleTheme} aria-label="Toggle theme">
-          {isDark ? <Sun size={16} /> : <Moon size={16} />}
-        </ThemeButton>
+        <SearchWrapper>
+          <InputWrapper>
+            <SearchInput
+              type="text"
+              placeholder="Search tasks..."
+              value={searchValue}
+              onChange={handleSearchChange}
+              onKeyDown={handleSearchKeyDown}
+              aria-label="Search tasks"
+              aria-expanded={isDropdownOpen}
+              aria-controls="search-results-listbox"
+              aria-activedescendant={
+                highlightedIndex >= 0 ? `search-result-${highlightedIndex}` : undefined
+              }
+            />
+            {isDropdownOpen && (
+              <ClearButton onClick={handleClear} aria-label="Clear search">
+                <X size={14} />
+              </ClearButton>
+            )}
+          </InputWrapper>
+          {isDropdownOpen && (
+            <SearchResults
+              tasks={filteredTasks}
+              selectedTaskId={selectedTaskId}
+              highlightedIndex={highlightedIndex}
+              onSelect={handleResultSelect}
+            />
+          )}
+        </SearchWrapper>
       </ControlsGroup>
     </Header>
   );

--- a/frontend/src/components/Calendar/DayCell.tsx
+++ b/frontend/src/components/Calendar/DayCell.tsx
@@ -2,6 +2,7 @@ import type { Task } from '@calendar/shared';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import type { PublicHoliday } from '../../services/holidayService';
 import { formatDateKey } from '../../utils/calendar';
@@ -17,6 +18,7 @@ interface DayCellProps {
   onEdit: (task: Task) => void;
   onDelete: (task: Task) => void;
   onAddTask: (dateKey: string) => void;
+  dropPreviewIndex?: number | null;
 }
 
 const Cell = styled.div<{ isBoundary: boolean; isToday: boolean }>`
@@ -74,13 +76,14 @@ const TaskCount = styled.span`
 
 const TasksContainer = styled.div`
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => theme.spacing.xs};
   overflow: hidden;
 `;
 
-const AddButton = styled.button`
+const AddButton = styled.button<{ visible: boolean }>`
   margin-top: ${({ theme }) => theme.spacing.xs};
   padding: ${({ theme }) => theme.spacing.xs};
   border: 1px dashed ${({ theme }) => theme.colors.addButtonBorder};
@@ -93,11 +96,8 @@ const AddButton = styled.button`
   color: ${({ theme }) => theme.colors.addButtonText};
   font-size: ${({ theme }) => theme.font.size.md};
   transition: opacity 0.15s ease;
-  opacity: 0;
-
-  ${Cell}:hover & {
-    opacity: 1;
-  }
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  pointer-events: ${({ visible }) => (visible ? 'auto' : 'none')};
 
   &:hover {
     border-color: ${({ theme }) => theme.colors.accent};
@@ -112,6 +112,13 @@ const MoreLink = styled.span`
   cursor: default;
 `;
 
+const DropIndicator = styled.div`
+  height: 1px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.accent};
+  margin: 2px 0;
+`;
+
 export function DayCell({
   date,
   isBoundary,
@@ -121,7 +128,11 @@ export function DayCell({
   onAddTask,
   onEdit,
   onDelete,
+  dropPreviewIndex,
 }: DayCellProps) {
+  const [isCellHovered, setIsCellHovered] = useState(false);
+  const [isTaskCardHovered, setIsTaskCardHovered] = useState(false);
+
   const MAX_VISIBLE = 2;
   const dateKey = formatDateKey(date);
   const dayNumber = date.getDate();
@@ -129,12 +140,23 @@ export function DayCell({
   const hiddenCount = tasks.length - visibleTasks.length;
   const taskIds = visibleTasks.map(t => t.id);
 
+  const showAddButton = isCellHovered && !isTaskCardHovered;
+
   const { setNodeRef: setDroppableRef } = useDroppable({
     id: `droppable-${dateKey}`,
   });
 
   return (
-    <Cell ref={setDroppableRef} isBoundary={isBoundary} isToday={isToday}>
+    <Cell
+      ref={setDroppableRef}
+      isBoundary={isBoundary}
+      isToday={isToday}
+      onMouseEnter={() => setIsCellHovered(true)}
+      onMouseLeave={() => {
+        setIsCellHovered(false);
+        setIsTaskCardHovered(false);
+      }}
+    >
       <Header>
         {isToday && !isBoundary ? (
           <TodayBadge>{dayNumber}</TodayBadge>
@@ -154,16 +176,28 @@ export function DayCell({
 
       <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>
         <TasksContainer>
-          {visibleTasks.map(task => (
-            <TaskCard key={task.id} task={task} onEdit={onEdit} onDelete={onDelete} />
+          {visibleTasks.map((task, i) => (
+            <div
+              key={task.id}
+              onMouseEnter={() => setIsTaskCardHovered(true)}
+              onMouseLeave={() => setIsTaskCardHovered(false)}
+            >
+              {dropPreviewIndex === i && <DropIndicator />}
+              <TaskCard task={task} onEdit={onEdit} onDelete={onDelete} />
+            </div>
           ))}
+          {dropPreviewIndex === visibleTasks.length && <DropIndicator />}
         </TasksContainer>
       </SortableContext>
 
       {hiddenCount > 0 && <MoreLink>+{hiddenCount} more</MoreLink>}
 
       {!isBoundary && (
-        <AddButton onClick={() => onAddTask(dateKey)} aria-label={`Add task for ${dateKey}`}>
+        <AddButton
+          visible={showAddButton}
+          onClick={() => onAddTask(dateKey)}
+          aria-label={`Add task for ${dateKey}`}
+        >
           +
         </AddButton>
       )}

--- a/frontend/src/components/Calendar/DeleteConfirmModal.tsx
+++ b/frontend/src/components/Calendar/DeleteConfirmModal.tsx
@@ -74,7 +74,11 @@ const Button = styled.button`
   font-size: ${({ theme }) => theme.font.size.md};
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 `;
 
 const CancelButton = styled(Button)`

--- a/frontend/src/components/Calendar/EditTaskModal.tsx
+++ b/frontend/src/components/Calendar/EditTaskModal.tsx
@@ -85,7 +85,11 @@ const PriorityButton = styled.button<{ active: boolean; priorityColor: string }>
   font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 
   &:hover {
     border-color: ${({ priorityColor }) => priorityColor};
@@ -106,7 +110,10 @@ const LabelSwatch = styled.button<{ swatchColor: string; selected: boolean }>`
   cursor: pointer;
   outline-offset: 2px;
   opacity: ${({ selected }) => (selected ? 1 : 0.5)};
-  transition: all 0.15s ease;
+  transition:
+    opacity 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 
   &:hover {
     opacity: 1;
@@ -126,7 +133,11 @@ const Button = styled.button`
   font-size: ${({ theme }) => theme.font.size.md};
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
 `;
 
 const CancelButton = styled(Button)`

--- a/frontend/src/components/Calendar/SearchResults.tsx
+++ b/frontend/src/components/Calendar/SearchResults.tsx
@@ -1,0 +1,213 @@
+import type { Task } from '@calendar/shared';
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+
+import { formatDateKey } from '../../utils/calendar';
+
+interface SearchResultsProps {
+  tasks: Task[];
+  highlightedIndex: number;
+  selectedTaskId?: string | null;
+  onSelect: (task: Task) => void;
+}
+
+const PAGE_SIZE = 5;
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const Dropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 400px;
+  max-height: 300px;
+  overflow-y: auto;
+  background: ${({ theme }) => theme.colors.background};
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  border-radius: 10px;
+  box-shadow: ${({ theme }) => theme.colors.cardShadow};
+  z-index: 100;
+  margin-top: 4px;
+`;
+
+const ResultRow = styled.div<{ isActive: boolean; isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  padding: 10px 14px;
+  cursor: pointer;
+  background: ${({ theme, isActive, isSelected }) =>
+    isActive || isSelected ? theme.colors.surfaceHover : 'transparent'};
+  transition: background-color 100ms ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+
+  &:first-of-type {
+    border-radius: 10px 10px 0 0;
+  }
+`;
+
+const DateText = styled.span`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  min-width: 100px;
+`;
+
+const Title = styled.span`
+  flex: 1;
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${({ theme }) => theme.font.size.md};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const PriorityBadge = styled.span<{ priorityColor: string; priorityBg: string }>`
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: ${({ priorityColor }) => priorityColor};
+  background: ${({ priorityBg }) => priorityBg};
+  white-space: nowrap;
+`;
+
+const LabelsGroup = styled.div`
+  display: flex;
+  gap: 3px;
+  align-items: center;
+`;
+
+const LabelDot = styled.span<{ color: string }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ color }) => color};
+`;
+
+const TodayBadge = styled.span`
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: #ffffff;
+  background: ${({ theme }) => theme.colors.todayBadge};
+  white-space: nowrap;
+`;
+
+const EmptyMessage = styled.div`
+  padding: 16px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font-size: ${({ theme }) => theme.font.size.md};
+`;
+
+const LoadMoreButton = styled.button`
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.borderLight};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.accent};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 0 0 10px 10px;
+  transition: background-color 100ms ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+
+  &:focus-visible {
+    outline: none;
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+`;
+
+export function SearchResults({
+  tasks,
+  highlightedIndex,
+  onSelect,
+  selectedTaskId,
+}: SearchResultsProps) {
+  const theme = useTheme();
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const todayKey = formatDateKey(new Date());
+
+  // Reset pagination when results change
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [tasks]);
+
+  // Auto-expand when keyboard nav exceeds visible items
+  useEffect(() => {
+    if (highlightedIndex >= visibleCount) {
+      setVisibleCount(prev => Math.max(prev, highlightedIndex + 1));
+    }
+  }, [highlightedIndex, visibleCount]);
+
+  const sortedTasks = [...tasks].sort((a, b) => b.date.localeCompare(a.date));
+
+  const visibleTasks = sortedTasks.slice(0, visibleCount);
+  const hasMore = visibleCount < sortedTasks.length;
+
+  if (tasks.length === 0) {
+    return (
+      <Dropdown role="listbox" id="search-results-listbox">
+        <EmptyMessage>No results found</EmptyMessage>
+      </Dropdown>
+    );
+  }
+
+  return (
+    <Dropdown role="listbox" id="search-results-listbox">
+      {visibleTasks.map((task, index) => {
+        const date = new Date(task.date + 'T00:00:00');
+        const priorityStyle = task.priority ? theme.priority[task.priority] : null;
+
+        return (
+          <ResultRow
+            key={task.id}
+            id={`search-result-${index}`}
+            role="option"
+            aria-selected={index === highlightedIndex}
+            isActive={index === highlightedIndex}
+            isSelected={task.id === selectedTaskId}
+            onClick={() => onSelect(task)}
+          >
+            <DateText>{dateFormatter.format(date)}</DateText>
+            <Title>{task.title}</Title>
+            {task.date === todayKey && <TodayBadge>Today</TodayBadge>}
+            {task.labels.length > 0 && (
+              <LabelsGroup>
+                {task.labels.map(label => (
+                  <LabelDot key={label} color={label} />
+                ))}
+              </LabelsGroup>
+            )}
+            {priorityStyle && (
+              <PriorityBadge priorityColor={priorityStyle.color} priorityBg={priorityStyle.bg}>
+                {task.priority}
+              </PriorityBadge>
+            )}
+          </ResultRow>
+        );
+      })}
+      {hasMore && (
+        <LoadMoreButton onClick={() => setVisibleCount(prev => prev + PAGE_SIZE)}>
+          Show more ({sortedTasks.length - visibleCount} remaining)
+        </LoadMoreButton>
+      )}
+    </Dropdown>
+  );
+}

--- a/frontend/src/components/Calendar/TaskCard.tsx
+++ b/frontend/src/components/Calendar/TaskCard.tsx
@@ -8,17 +8,21 @@ interface TaskCardProps {
   task: Task;
   onEdit: (task: Task) => void;
   onDelete: (task: Task) => void;
+  forceDraggingCursor?: boolean;
 }
 
-const Card = styled.div`
+const Card = styled.div<{ isDragging: boolean }>`
   background: ${({ theme }) => theme.colors.cardBg};
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
   box-shadow: ${({ theme }) => theme.colors.cardShadow};
   border-radius: ${({ theme }) => theme.borderRadius};
   padding: ${({ theme }) => theme.spacing.sm};
   overflow: hidden;
-  cursor: grab;
+  cursor: ${({ isDragging }) => (isDragging ? 'grabbing' : 'grab')};
   touch-action: manipulation;
+
+  flex-shrink: 0;
+  min-height: 64px;
 
   &:active {
     cursor: grabbing;
@@ -48,11 +52,12 @@ const LabelBar = styled.div<{ color: string }>`
 const Title = styled.span`
   display: block;
   font-size: ${({ theme }) => theme.font.size.sm};
+  line-height: 1.35;
   color: ${({ theme }) => theme.colors.text};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  cursor: pointer;
+  cursor: inherit;
 `;
 
 const PriorityBadge = styled.span<{ priority: string }>`
@@ -115,7 +120,7 @@ const DeleteButton = styled(ActionButton)`
   }
 `;
 
-export function TaskCard({ task, onEdit, onDelete }: TaskCardProps) {
+export function TaskCard({ task, onEdit, onDelete, forceDraggingCursor = false }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: task.id,
   });
@@ -127,7 +132,13 @@ export function TaskCard({ task, onEdit, onDelete }: TaskCardProps) {
   };
 
   return (
-    <Card ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <Card
+      ref={setNodeRef}
+      style={style}
+      isDragging={isDragging || forceDraggingCursor}
+      {...attributes}
+      {...listeners}
+    >
       <TopRow>
         <Labels>
           {task.labels.map(color => (

--- a/frontend/src/components/ui/CustomSelect.tsx
+++ b/frontend/src/components/ui/CustomSelect.tsx
@@ -1,0 +1,182 @@
+import styled from '@emotion/styled';
+import { ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+type SelectValue = string | number;
+
+export interface SelectOption<T extends SelectValue> {
+  value: T;
+  label: string;
+}
+
+interface CustomSelectProps<T extends SelectValue> {
+  value: T;
+  options: SelectOption<T>[];
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  size?: 'md' | 'lg';
+  minWidth?: string;
+  borderMode?: 'transparent' | 'light';
+}
+
+const Wrap = styled.div<{ minWidth?: string }>`
+  position: relative;
+  min-width: ${({ minWidth }) => minWidth ?? '180px'};
+`;
+
+const Trigger = styled.button<{
+  size: 'md' | 'lg';
+  isOpen: boolean;
+  borderMode: 'transparent' | 'light';
+}>`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.sm};
+  border-radius: 10px;
+  border: 1px solid
+    ${({ theme, isOpen, borderMode }) =>
+      isOpen
+        ? theme.colors.accent
+        : borderMode === 'transparent'
+          ? 'transparent'
+          : theme.colors.borderLight};
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+  padding: ${({ size }) => (size === 'lg' ? '6px 12px' : '10px 14px')};
+  font-size: ${({ theme, size }) => (size === 'lg' ? '22px' : theme.font.size.md)};
+  font-weight: ${({ size }) => (size === 'lg' ? 600 : 400)};
+  box-shadow: ${({ theme, isOpen }) => (isOpen ? `0 0 0 3px ${theme.colors.accent}33` : 'none')};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.accent};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
+  }
+`;
+
+const Label = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const Menu = styled.ul`
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.borderLight};
+  background: ${({ theme }) => theme.colors.background};
+  max-height: 260px;
+  overflow-y: auto;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
+  z-index: 50;
+`;
+
+const OptionButton = styled.button<{ active: boolean }>`
+  width: 100%;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 10px;
+  text-align: left;
+  background: ${({ active }) => (active ? 'transparent' : 'transparent')};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 14px;
+  font-weight: 400;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.accent};
+    outline-offset: 1px;
+  }
+`;
+
+export function CustomSelect<T extends SelectValue>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  size = 'md',
+  minWidth,
+  borderMode = 'light',
+}: CustomSelectProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selected = options.find(o => o.value === value);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onOutside = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false);
+    };
+    const onEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', onOutside);
+    document.addEventListener('keydown', onEscape);
+    return () => {
+      document.removeEventListener('mousedown', onOutside);
+      document.removeEventListener('keydown', onEscape);
+    };
+  }, [isOpen]);
+
+  return (
+    <Wrap ref={rootRef} minWidth={minWidth}>
+      <Trigger
+        type="button"
+        size={size}
+        isOpen={isOpen}
+        borderMode={borderMode}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen(prev => !prev)}
+      >
+        <Label>{selected?.label ?? String(value)}</Label>
+        <ChevronDown size={16} />
+      </Trigger>
+
+      {isOpen && (
+        <Menu role="listbox" aria-label={ariaLabel}>
+          {options.map(option => (
+            <li key={String(option.value)}>
+              <OptionButton
+                type="button"
+                role="option"
+                aria-selected={option.value === value}
+                active={option.value === value}
+                onClick={() => {
+                  onChange(option.value);
+                  setIsOpen(false);
+                }}
+              >
+                {option.label}
+              </OptionButton>
+            </li>
+          ))}
+        </Menu>
+      )}
+    </Wrap>
+  );
+}

--- a/frontend/src/store/tasksSlice.ts
+++ b/frontend/src/store/tasksSlice.ts
@@ -4,19 +4,26 @@ import { createAsyncThunk, createSelector, createSlice, PayloadAction } from '@r
 import api from '../services/taskService';
 
 export interface TasksState {
-  tasks: Task[];
+  tasks: Task[]; // month-scoped, used by calendar grid
+  allTasks: Task[]; // all tasks, used by search dropdown
   loading: boolean;
   error: string | null;
 }
 
 const initialState: TasksState = {
   tasks: [],
+  allTasks: [],
   loading: false,
   error: null,
 };
 
-export const fetchTasks = createAsyncThunk('tasks/fetchTasks', async (month: string) => {
+export const fetchTasksByMonthYear = createAsyncThunk('tasks/fetchTasks', async (month: string) => {
   const { data } = await api.get<Task[]>('/tasks', { params: { month } });
+  return data;
+});
+
+export const fetchAllTasks = createAsyncThunk('tasks/fetchAllTasks', async () => {
+  const { data } = await api.get<Task[]>('/tasks');
   return data;
 });
 
@@ -59,15 +66,15 @@ const tasksSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(fetchTasks.pending, state => {
+      .addCase(fetchTasksByMonthYear.pending, state => {
         state.loading = true;
         state.error = null;
       })
-      .addCase(fetchTasks.fulfilled, (state, action) => {
+      .addCase(fetchTasksByMonthYear.fulfilled, (state, action) => {
         state.loading = false;
         state.tasks = action.payload;
       })
-      .addCase(fetchTasks.rejected, (state, action) => {
+      .addCase(fetchTasksByMonthYear.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message ?? 'Failed to fetch tasks';
       })
@@ -86,6 +93,18 @@ const tasksSlice = createSlice({
       })
       .addCase(reorderTasks.rejected, (state, action) => {
         state.error = action.error.message ?? 'Failed to reorder tasks';
+      })
+      .addCase(fetchAllTasks.pending, state => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchAllTasks.fulfilled, (state, action) => {
+        state.loading = false;
+        state.allTasks = action.payload;
+      })
+      .addCase(fetchAllTasks.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message ?? 'Failed to fetch tasks';
       });
   },
 });
@@ -95,7 +114,7 @@ export const { optimisticReorder } = tasksSlice.actions;
 
 export const selectFilteredTasks = createSelector(
   [
-    (state: { tasks: TasksState }) => state.tasks.tasks,
+    (state: { tasks: TasksState }) => state.tasks.allTasks,
     (_state: { tasks: TasksState }, query: string) => query,
   ],
   (tasks, query) =>

--- a/frontend/src/styles/GlobalStyles.tsx
+++ b/frontend/src/styles/GlobalStyles.tsx
@@ -8,10 +8,33 @@ export function GlobalStyles() {
       styles={css`
         body {
           margin: 0;
-          background: ${theme.colors.background};
+          background-color: ${theme.colors.background};
           font-family: ${theme.font.family};
           color: ${theme.colors.text};
-          transition: background 0.2s;
+          transition:
+            background-color 200ms ease,
+            color 200ms ease,
+            border-color 200ms ease,
+            box-shadow 200ms ease;
+        }
+
+        *,
+        *::before,
+        *::after {
+          transition:
+            background-color 200ms ease,
+            color 200ms ease,
+            border-color 200ms ease,
+            box-shadow 200ms ease;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          *,
+          *::before,
+          *::after {
+            transition: none !important;
+            animation: none !important;
+          }
         }
       `}
     />


### PR DESCRIPTION
## Summary

- Add global task search with typeahead dropdown (SearchResults component)
- Replace native `<select>` elements with custom styled CustomSelect component
- Add AppHeader with dark/light theme toggle
- Make backend `GET /tasks` month parameter optional (returns all tasks when omitted)
- Polish DayCell overflow, favicon, and modal styling

## Changes

- `backend/src/controllers/taskController.ts` — make `month` query param optional for global search
- `frontend/src/components/Calendar/SearchResults.tsx` — **new** — paginated dropdown with keyboard nav, Today badge, ARIA listbox
- `frontend/src/components/ui/CustomSelect.tsx` — **new** — styled dropdown replacing native `<select>`
- `frontend/src/components/AppHeader.tsx` — **new** — app title + dark/light theme toggle
- `frontend/public/favicon.svg` — **new** — calendar favicon
- `frontend/src/store/tasksSlice.ts` — add `allTasks` state + `fetchAllTasks` thunk for global search
- `frontend/src/components/Calendar/CalendarHeader.tsx` — wire search input with debounce, keyboard nav, clear button
- `frontend/src/components/Calendar/Calendar.tsx` — add search result navigation (month/year jump)
- `frontend/src/components/Calendar/DayCell.tsx` — improve task overflow display
- `frontend/src/components/Calendar/TaskCard.tsx` — minor styling tweaks
- `frontend/src/components/Calendar/EditTaskModal.tsx` — minor styling tweaks
- `frontend/src/components/Calendar/DeleteConfirmModal.tsx` — minor styling tweaks
- `frontend/src/styles/GlobalStyles.tsx` — update for theme toggle support
- `frontend/src/App.tsx` — integrate AppHeader
- `frontend/index.html` — update favicon reference
- `frontend/public/index.html` — **removed** (replaced by root index.html)

## Test Plan

- [ ] Type in search → dropdown shows matching tasks from all months
- [ ] Results paginated (5 at a time), "Show more" loads next batch
- [ ] Keyboard: ArrowDown/Up navigates, Enter selects, Escape closes
- [ ] Click result → calendar navigates to task's month, dropdown stays open
- [ ] Selected task shows grey background in dropdown
- [ ] Tasks dated today show "Today" badge
- [ ] Clear (X) button appears when text present, clears search on click
- [ ] CustomSelect dropdowns work for month, year, country
- [ ] Theme toggle switches between light/dark mode
- [ ] Backend: `GET /api/tasks` without `month` param returns all tasks
- [ ] Backend: `GET /api/tasks?month=2026-03` still returns month-scoped tasks

Closes #18 