### PR TITLE
(SP: 5) [Feature] DnD + Holidays + Global Search + Calendar UX hardening

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { AppHeader } from './components/AppHeader';
 import { Calendar } from './components/Calendar/Calendar';
@@ -15,10 +15,27 @@ const Container = styled.div`
 `;
 
 export const App = () => {
-  const [isDark, setIsDark] = useState(false);
+  const [isDark, setIsDark] = useState(() => {
+    try {
+      return localStorage.getItem('calendar-theme') === 'dark';
+    } catch {
+      return false;
+    }
+  });
+
   const { countries, country, setCountry } = useCountries();
 
   const toggleTheme = useCallback(() => setIsDark(prev => !prev), []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('calendar-theme', isDark ? 'dark' : 'light');
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('Theme persistence failed', error);
+      }
+    }
+  }, [isDark]);
 
   return (
     <ThemeProvider theme={isDark ? darkTheme : lightTheme}>

--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -19,7 +19,7 @@ import { useAppDispatch, useAppSelector } from '../../store';
 import {
   createTask,
   deleteTask,
-  fetchTasksByMonthYear,
+  fetchTasksByMonths,
   optimisticReorder,
   reorderTasks,
   updateTask,
@@ -27,6 +27,7 @@ import {
 import { formatDateKey } from '../../utils/calendar';
 import { CalendarHeader } from './CalendarHeader';
 import { DayCell } from './DayCell';
+import { DayTasksModal } from './DayTasksModal';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { EditTaskModal } from './EditTaskModal';
 import { TaskCard } from './TaskCard';
@@ -83,15 +84,53 @@ const todayKey = formatDateKey(new Date());
 export function Calendar({ countries, country, onCountryChange }: CalendarProps) {
   const { grid, currentMonth, currentYear, setCalendarMonth, setCalendarYear } = useCalendar();
   const [dropPreview, setDropPreview] = useState<{ dateKey: string; index: number } | null>(null);
+  const [highlightedDateKey, setHighlightedDateKey] = useState<string | null>(null);
+  const [editingState, setEditingState] = useState<{ task: Task | null; dateKey: string } | null>(
+    null
+  );
+  const [deletingTask, setDeletingTask] = useState<Task | null>(null);
+  const [expandedDayKey, setExpandedDayKey] = useState<string | null>(null);
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
   const holidays = useHolidays(currentYear, country);
   const tasks = useAppSelector(state => state.tasks.tasks);
 
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    const month = `${currentYear}-${String(currentMonth + 1).padStart(2, '0')}`;
-    dispatch(fetchTasksByMonthYear(month));
+    const formatMonth = (date: Date) =>
+      `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+
+    const current = new Date(currentYear, currentMonth, 1);
+    const prev = new Date(currentYear, currentMonth - 1, 1);
+    const next = new Date(currentYear, currentMonth + 1, 1);
+
+    dispatch(fetchTasksByMonths([formatMonth(prev), formatMonth(current), formatMonth(next)]));
   }, [dispatch, currentYear, currentMonth]);
+
+  useEffect(() => {
+    if (!highlightedDateKey) return;
+
+    const timer = window.setTimeout(() => {
+      setHighlightedDateKey(null);
+    }, 2000);
+
+    return () => window.clearTimeout(timer);
+  }, [highlightedDateKey]);
+
+  useEffect(() => {
+    if (!highlightedDateKey) return;
+
+    const cell = document.querySelector(
+      `[data-date-key="${highlightedDateKey}"]`
+    ) as HTMLElement | null;
+    if (!cell) return;
+
+    cell.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'center',
+    });
+  }, [highlightedDateKey]);
 
   const tasksByDate = useMemo(() => {
     const map = new Map<string, typeof tasks>();
@@ -109,12 +148,6 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
     return map;
   }, [tasks]);
 
-  const [editingState, setEditingState] = useState<{ task: Task | null; dateKey: string } | null>(
-    null
-  );
-  const [deletingTask, setDeletingTask] = useState<Task | null>(null);
-  const [activeTask, setActiveTask] = useState<Task | null>(null);
-
   const handleAddTask = useCallback((dateKey: string) => {
     setEditingState({ task: null, dateKey });
   }, []);
@@ -128,7 +161,16 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
   }, []);
 
   const handleSave = useCallback(
-    (data: { title: string; priority?: Priority; labels: string[] }, taskId?: string) => {
+    (
+      data: {
+        title: string;
+        priority?: Priority;
+        labels: string[];
+        description?: string;
+        date?: string;
+      },
+      taskId?: string
+    ) => {
       if (taskId) {
         dispatch(updateTask({ id: taskId, ...data }));
       } else if (editingState?.dateKey) {
@@ -147,6 +189,12 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
     },
     [dispatch]
   );
+
+  const handleOpenDayTasks = useCallback((dateKey: string) => {
+    setExpandedDayKey(dateKey);
+  }, []);
+
+  const expandedDayTasks = expandedDayKey ? (tasksByDate.get(expandedDayKey) ?? []) : [];
 
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
@@ -267,11 +315,12 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
   }, []);
 
   const handleSelectSearchResult = useCallback(
-    (task: Task) => {
+    (task: Task, dateKey: string) => {
       const year = parseInt(task.date.slice(0, 4));
       const month = parseInt(task.date.slice(5, 7)) - 1;
       setCalendarMonth(month);
       setCalendarYear(year);
+      setHighlightedDateKey(dateKey);
     },
     [setCalendarMonth, setCalendarYear]
   );
@@ -315,6 +364,8 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
                     onAddTask={handleAddTask}
                     onEdit={handleEdit}
                     onDelete={handleDelete}
+                    onOpenDayTasks={handleOpenDayTasks}
+                    isSearchHighlighted={highlightedDateKey === key}
                     dropPreviewIndex={dropPreview?.dateKey === key ? dropPreview.index : null}
                   />
                 );
@@ -328,6 +379,25 @@ export function Calendar({ countries, country, onCountryChange }: CalendarProps)
           ) : null}
         </DragOverlay>
       </DndContext>
+      {expandedDayKey && (
+        <DayTasksModal
+          dateKey={expandedDayKey}
+          tasks={expandedDayTasks}
+          onClose={() => setExpandedDayKey(null)}
+          onAddTask={dateKey => {
+            setExpandedDayKey(null);
+            handleAddTask(dateKey);
+          }}
+          onEditTask={task => {
+            setExpandedDayKey(null);
+            handleEdit(task);
+          }}
+          onDeleteTask={task => {
+            setExpandedDayKey(null);
+            handleDelete(task);
+          }}
+        />
+      )}
       {editingState && (
         <EditTaskModal
           task={editingState.task}

--- a/frontend/src/components/Calendar/CalendarHeader.tsx
+++ b/frontend/src/components/Calendar/CalendarHeader.tsx
@@ -15,7 +15,7 @@ interface CalendarHeaderProps {
   countries: Country[];
   country: string;
   onCountryChange: (code: string) => void;
-  onSelectSearchResult: (task: Task) => void;
+  onSelectSearchResult: (task: Task, dateKey: string) => void;
 }
 
 const Header = styled.header`
@@ -25,18 +25,21 @@ const Header = styled.header`
   padding: 20px 28px;
   flex-wrap: wrap;
   gap: ${({ theme }) => theme.spacing.md};
+  row-gap: ${({ theme }) => theme.spacing.sm};
 `;
 
 const NavGroup = styled.div`
   display: flex;
   align-items: center;
-  gap: ${({ theme }) => theme.spacing.lg};
+  gap: ${({ theme }) => theme.spacing.sm};
+  flex-shrink: 0;
+  flex-wrap: nowrap;
 `;
 
 const ControlsGroup = styled.div`
   display: flex;
   align-items: center;
-  gap: ${({ theme }) => theme.spacing.md};
+  gap: ${({ theme }) => theme.spacing.sm};
 `;
 
 const NavButton = styled.button`
@@ -68,14 +71,47 @@ const NavButton = styled.button`
   }
 `;
 
+const TodayButton = styled.button<{ isActive: boolean }>`
+  height: 36px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ theme, isActive }) =>
+    isActive ? `${theme.colors.accent}14` : theme.colors.background};
+  border: 1px solid
+    ${({ theme, isActive }) => (isActive ? `${theme.colors.accent}55` : theme.colors.borderLight)};
+  border-radius: 10px;
+  color: ${({ theme, isActive }) => (isActive ? theme.colors.accent : theme.colors.textSecondary)};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ isActive }) => (isActive ? 700 : 600)};
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+
+  &:hover {
+    background: ${({ theme, isActive }) =>
+      isActive ? `${theme.colors.accent}24` : theme.colors.surfaceHover};
+  }
+
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.colors.accent};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
+    outline: none;
+  }
+`;
+
 const SearchInput = styled.input`
-  padding: 10px 32px 10px 14px;
+  padding: 10px 14px 10px 14px;
   border-radius: 10px;
   border: 1px solid ${({ theme }) => theme.colors.borderLight};
   background: ${({ theme }) => theme.colors.background};
   color: ${({ theme }) => theme.colors.text};
   font-size: ${({ theme }) => theme.font.size.md};
-  width: 220px;
+  width: 100%;
   outline: none;
   transition:
     background-color 150ms ease,
@@ -87,6 +123,11 @@ const SearchInput = styled.input`
     color: ${({ theme }) => theme.colors.textSecondary};
   }
 
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+    border-color: ${({ theme }) => theme.colors.borderLight};
+  }
+
   &:focus {
     border-color: ${({ theme }) => theme.colors.accent};
     box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
@@ -95,6 +136,9 @@ const SearchInput = styled.input`
 
 const SearchWrapper = styled.div`
   position: relative;
+  width: 180px;
+  min-width: 100px;
+  flex-shrink: 1;
 `;
 
 const InputWrapper = styled.div`
@@ -146,7 +190,16 @@ export function CalendarHeader({
     setCalendarYear,
   } = useCalendar();
 
-  const yearRange = Array.from({ length: 21 }, (_, i) => currentYear - 10 + i);
+  const [yearBounds, setYearBounds] = useState(() => ({
+    start: currentYear - 10,
+    end: currentYear + 10,
+  }));
+  const isAdjustingYearsRef = useRef(false);
+
+  const yearRange = Array.from(
+    { length: yearBounds.end - yearBounds.start + 1 },
+    (_, i) => yearBounds.start + i
+  );
 
   const monthOptions = MONTHS.map((label, value) => ({ value, label }));
   const yearOptions = yearRange.map(y => ({ value: y, label: String(y) }));
@@ -155,19 +208,68 @@ export function CalendarHeader({
   const [searchValue, setSearchValue] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const allFetchedRef = useRef(false);
+  const searchAreaRef = useRef<HTMLDivElement>(null);
 
   const filteredTasks = useAppSelector(state => selectFilteredTasks(state, searchValue));
 
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-
-  // Reset highlighted index when search value changes
-  useEffect(() => {
-    setHighlightedIndex(-1);
-    setSelectedTaskId(null);
-  }, [searchValue]);
-
   const isDropdownOpen = searchValue.trim() !== '';
+
+  const now = new Date();
+  const isTodayMonth = currentYear === now.getFullYear() && currentMonth === now.getMonth();
+
+  const handleYearMenuScroll = useCallback((event: React.UIEvent<HTMLUListElement>) => {
+    if (isAdjustingYearsRef.current) return;
+
+    const menu = event.currentTarget;
+    const { scrollTop, scrollHeight, clientHeight } = menu;
+    const threshold = 24;
+
+    const nearBottom = scrollHeight - (scrollTop + clientHeight) <= threshold;
+    const nearTop = scrollTop <= threshold;
+
+    if (nearBottom) {
+      isAdjustingYearsRef.current = true;
+      setYearBounds(prev => ({ ...prev, end: prev.end + 10 }));
+      requestAnimationFrame(() => {
+        isAdjustingYearsRef.current = false;
+      });
+      return;
+    }
+
+    if (nearTop) {
+      isAdjustingYearsRef.current = true;
+      const prevHeight = scrollHeight;
+      setYearBounds(prev => ({ start: prev.start - 10, end: prev.end }));
+      requestAnimationFrame(() => {
+        const nextHeight = menu.scrollHeight;
+        menu.scrollTop += nextHeight - prevHeight;
+        isAdjustingYearsRef.current = false;
+      });
+    }
+  }, []);
+
+  const handleYearMenuWheel = useCallback((event: React.WheelEvent<HTMLUListElement>) => {
+    if (isAdjustingYearsRef.current) return;
+
+    const menu = event.currentTarget;
+    const isScrollingUp = event.deltaY < 0;
+    const threshold = 2;
+
+    if (isScrollingUp && menu.scrollTop <= threshold) {
+      isAdjustingYearsRef.current = true;
+      const prevHeight = menu.scrollHeight;
+
+      setYearBounds(prev => ({ start: prev.start - 10, end: prev.end }));
+
+      requestAnimationFrame(() => {
+        const nextHeight = menu.scrollHeight;
+        menu.scrollTop += nextHeight - prevHeight;
+        isAdjustingYearsRef.current = false;
+      });
+    }
+  }, []);
 
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -194,7 +296,7 @@ export function CalendarHeader({
   const handleResultSelect = useCallback(
     (task: Task) => {
       setSelectedTaskId(task.id);
-      onSelectSearchResult(task);
+      onSelectSearchResult(task, task.date);
     },
     [onSelectSearchResult]
   );
@@ -207,6 +309,40 @@ export function CalendarHeader({
     setSelectedTaskId(null);
     setHighlightedIndex(-1);
   }, [dispatch]);
+
+  // Reset highlighted index when search value changes
+  useEffect(() => {
+    setHighlightedIndex(-1);
+    setSelectedTaskId(null);
+  }, [searchValue]);
+
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+
+    const handleDocumentPointerDown = (event: MouseEvent) => {
+      if (!searchAreaRef.current?.contains(event.target as Node)) {
+        handleClear();
+      }
+    };
+
+    const handleWindowBlur = () => {
+      handleClear();
+    };
+
+    document.addEventListener('mousedown', handleDocumentPointerDown);
+    window.addEventListener('blur', handleWindowBlur);
+
+    return () => {
+      document.removeEventListener('mousedown', handleDocumentPointerDown);
+      window.removeEventListener('blur', handleWindowBlur);
+    };
+  }, [isDropdownOpen, handleClear]);
+
+  const goToToday = useCallback(() => {
+    const now = new Date();
+    setCalendarYear(now.getFullYear());
+    setCalendarMonth(now.getMonth());
+  }, [setCalendarMonth, setCalendarYear]);
 
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -239,6 +375,9 @@ export function CalendarHeader({
         <NavButton onClick={goToPrevMonth} aria-label="Previous month">
           <ChevronLeft size={18} />
         </NavButton>
+        <TodayButton isActive={!isTodayMonth} onClick={goToToday} aria-label="Go to current month">
+          Today
+        </TodayButton>
         <CustomSelect
           value={currentMonth}
           options={monthOptions}
@@ -246,15 +385,19 @@ export function CalendarHeader({
           ariaLabel="Select month"
           size="lg"
           minWidth="130px"
+          width="170px"
           borderMode="transparent"
         />
         <CustomSelect
           value={currentYear}
           options={yearOptions}
           onChange={setCalendarYear}
+          onMenuScroll={handleYearMenuScroll}
+          onMenuWheel={handleYearMenuWheel}
           ariaLabel="Select year"
           size="lg"
           minWidth="110px"
+          width="110px"
           borderMode="transparent"
         />
         <NavButton onClick={goToNextMonth} aria-label="Next month">
@@ -270,9 +413,10 @@ export function CalendarHeader({
           ariaLabel="Select country"
           size="md"
           minWidth="220px"
+          width="220px"
           borderMode="light"
         />
-        <SearchWrapper>
+        <SearchWrapper ref={searchAreaRef}>
           <InputWrapper>
             <SearchInput
               type="text"

--- a/frontend/src/components/Calendar/DayCell.tsx
+++ b/frontend/src/components/Calendar/DayCell.tsx
@@ -13,15 +13,17 @@ interface DayCellProps {
   date: Date;
   isBoundary: boolean;
   isToday: boolean;
+  isSearchHighlighted?: boolean;
   tasks: Task[];
   holidays: PublicHoliday[];
   onEdit: (task: Task) => void;
   onDelete: (task: Task) => void;
   onAddTask: (dateKey: string) => void;
+  onOpenDayTasks: (dateKey: string) => void;
   dropPreviewIndex?: number | null;
 }
 
-const Cell = styled.div<{ isBoundary: boolean; isToday: boolean }>`
+const Cell = styled.div<{ isBoundary: boolean; isToday: boolean; isSearchHighlighted: boolean }>`
   padding: ${({ theme }) => theme.spacing.sm};
   overflow: hidden;
   border-right: 1px solid ${({ theme }) => theme.colors.border};
@@ -29,7 +31,6 @@ const Cell = styled.div<{ isBoundary: boolean; isToday: boolean }>`
   background: ${({ theme, isToday, isBoundary }) =>
     isToday ? theme.colors.today : isBoundary ? theme.colors.surface : theme.colors.background};
   opacity: ${({ isBoundary }) => (isBoundary ? 0.5 : 1)};
-  pointer-events: ${({ isBoundary }) => (isBoundary ? 'none' : 'auto')};
   touch-action: manipulation;
   display: flex;
   flex-direction: column;
@@ -38,6 +39,12 @@ const Cell = styled.div<{ isBoundary: boolean; isToday: boolean }>`
   &:nth-of-type(7n + 7) {
     border-right: none;
   }
+
+  box-shadow: ${({ isSearchHighlighted, theme }) =>
+    isSearchHighlighted ? `inset 0 0 0 2px ${theme.colors.accent}` : 'none'};
+  transition:
+    box-shadow 220ms ease,
+    background-color 220ms ease;
 `;
 
 const Header = styled.div`
@@ -105,11 +112,19 @@ const AddButton = styled.button<{ visible: boolean }>`
   }
 `;
 
-const MoreLink = styled.span`
+const MoreLink = styled.button`
   font-size: ${({ theme }) => theme.font.size.sm};
-  color: ${({ theme }) => theme.colors.textSecondary};
+  color: ${({ theme }) => theme.colors.accent};
   margin-top: ${({ theme }) => theme.spacing.xs};
-  cursor: default;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 const DropIndicator = styled.div`
@@ -123,11 +138,13 @@ export function DayCell({
   date,
   isBoundary,
   isToday,
+  isSearchHighlighted = false,
   tasks,
   holidays,
   onAddTask,
   onEdit,
   onDelete,
+  onOpenDayTasks,
   dropPreviewIndex,
 }: DayCellProps) {
   const [isCellHovered, setIsCellHovered] = useState(false);
@@ -149,8 +166,10 @@ export function DayCell({
   return (
     <Cell
       ref={setDroppableRef}
+      data-date-key={dateKey}
       isBoundary={isBoundary}
       isToday={isToday}
+      isSearchHighlighted={isSearchHighlighted}
       onMouseEnter={() => setIsCellHovered(true)}
       onMouseLeave={() => {
         setIsCellHovered(false);
@@ -190,17 +209,21 @@ export function DayCell({
         </TasksContainer>
       </SortableContext>
 
-      {hiddenCount > 0 && <MoreLink>+{hiddenCount} more</MoreLink>}
-
-      {!isBoundary && (
-        <AddButton
-          visible={showAddButton}
-          onClick={() => onAddTask(dateKey)}
-          aria-label={`Add task for ${dateKey}`}
+      {hiddenCount > 0 && (
+        <MoreLink
+          onClick={() => onOpenDayTasks(dateKey)}
+          aria-label={`Show ${hiddenCount} more tasks`}
         >
-          +
-        </AddButton>
+          +{hiddenCount} more
+        </MoreLink>
       )}
+      <AddButton
+        visible={showAddButton}
+        onClick={() => onAddTask(dateKey)}
+        aria-label={`Add task for ${dateKey}`}
+      >
+        +
+      </AddButton>
     </Cell>
   );
 }

--- a/frontend/src/components/Calendar/DayTasksModal.tsx
+++ b/frontend/src/components/Calendar/DayTasksModal.tsx
@@ -1,0 +1,325 @@
+import type { Task } from '@calendar/shared';
+import styled from '@emotion/styled';
+import { Plus, SquarePen, X } from 'lucide-react';
+import { useEffect } from 'react';
+
+interface DayTasksModalProps {
+  dateKey: string;
+  tasks: Task[];
+  onClose: () => void;
+  onAddTask: (dateKey: string) => void;
+  onEditTask: (task: Task) => void;
+  onDeleteTask: (task: Task) => void;
+}
+
+const weekdayFormatter = new Intl.DateTimeFormat('en-US', { weekday: 'long' });
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.overlay};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 120;
+`;
+
+const Modal = styled.div`
+  width: 100%;
+  max-width: 480px;
+  max-height: 80vh;
+  background: ${({ theme }) => theme.colors.background};
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+const Header = styled.header`
+  padding: ${({ theme }) => theme.spacing.md};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+  display: flex;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+const HeaderMain = styled.div`
+  min-width: 0;
+`;
+
+const Weekday = styled.div`
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 13px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const DateTitle = styled.h2`
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const CloseButton = styled.button`
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.surfaceHover};
+  }
+`;
+
+const Body = styled.div`
+  padding: ${({ theme }) => theme.spacing.md};
+  overflow: auto;
+  flex: 1;
+`;
+
+const CountText = styled.div`
+  font-size: 18px;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  background: ${({ theme }) => theme.colors.border};
+  margin-bottom: ${({ theme }) => theme.spacing.lg};
+`;
+
+const TaskList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const TaskItem = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.cardBorder};
+  background: ${({ theme }) => theme.colors.cardBg};
+  box-shadow: ${({ theme }) => theme.colors.cardShadow};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  padding: ${({ theme }) => theme.spacing.sm};
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 20px;
+  min-width: 0;
+`;
+
+const Labels = styled.div`
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+`;
+
+const LabelBar = styled.span<{ color: string }>`
+  height: 4px;
+  flex: 1 1 0;
+  max-width: 32px;
+  min-width: 6px;
+  border-radius: 2px;
+  background: ${({ color }) => color};
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+`;
+
+const ActionButton = styled.button`
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.accent};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: ${({ theme }) => `${theme.colors.accent}22`};
+  }
+`;
+
+const DeleteButton = styled(ActionButton)`
+  color: ${({ theme }) => theme.colors.deleteHover};
+
+  &:hover {
+    background: ${({ theme }) => `${theme.colors.deleteHover}22`};
+  }
+`;
+
+const Title = styled.button`
+  margin-top: ${({ theme }) => theme.spacing.xs};
+  display: block;
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  font-size: ${({ theme }) => theme.font.size.md};
+  line-height: 1.35;
+  color: ${({ theme }) => theme.colors.text};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+`;
+
+const PriorityBadge = styled.span<{ priority: string }>`
+  display: inline-block;
+  margin-top: ${({ theme }) => theme.spacing.sm};
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: 600;
+  text-transform: uppercase;
+  color: ${({ theme, priority }) => theme.priority[priority as keyof typeof theme.priority].color};
+  background: ${({ theme, priority }) =>
+    theme.priority[priority as keyof typeof theme.priority].bg};
+`;
+
+const EmptyState = styled.div`
+  padding: ${({ theme }) => theme.spacing.lg} 0;
+  font-size: ${({ theme }) => theme.font.size.lg};
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+const Footer = styled.footer`
+  border-top: 1px solid ${({ theme }) => theme.colors.border};
+  padding: ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.md};
+`;
+
+const AddButton = styled.button`
+  width: 100%;
+  padding: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.accent};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.accent};
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.accentHover};
+    border-color: ${({ theme }) => theme.colors.accentHover};
+  }
+`;
+
+const AddText = styled.span`
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+`;
+
+export function DayTasksModal({
+  dateKey,
+  tasks,
+  onClose,
+  onAddTask,
+  onEditTask,
+  onDeleteTask,
+}: DayTasksModalProps) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const date = new Date(`${dateKey}T00:00:00`);
+  const weekday = weekdayFormatter.format(date).toUpperCase();
+
+  return (
+    <Backdrop onClick={onClose}>
+      <Modal onClick={e => e.stopPropagation()}>
+        <Header>
+          <HeaderMain>
+            <Weekday>{weekday}</Weekday>
+            <DateTitle>{dateFormatter.format(date)}</DateTitle>
+          </HeaderMain>
+          <CloseButton onClick={onClose} aria-label="Close tasks modal">
+            <X size={30} />
+          </CloseButton>
+        </Header>
+
+        <Body>
+          <CountText>
+            {tasks.length} task{tasks.length === 1 ? '' : 's'}
+          </CountText>
+          <Divider />
+          {tasks.length === 0 ? (
+            <EmptyState>No tasks for this day yet.</EmptyState>
+          ) : (
+            <TaskList>
+              {tasks.map(task => (
+                <TaskItem key={task.id}>
+                  <TopRow>
+                    <Labels>
+                      {task.labels.map(color => (
+                        <LabelBar key={color} color={color} />
+                      ))}
+                    </Labels>
+                    <Actions>
+                      <ActionButton onClick={() => onEditTask(task)} aria-label="Edit task">
+                        <SquarePen size={20} />
+                      </ActionButton>
+                      <DeleteButton onClick={() => onDeleteTask(task)} aria-label="Delete task">
+                        <X size={20} />
+                      </DeleteButton>
+                    </Actions>
+                  </TopRow>
+
+                  <Title onClick={() => onEditTask(task)}>{task.title}</Title>
+
+                  {task.priority && (
+                    <PriorityBadge priority={task.priority}>{task.priority}</PriorityBadge>
+                  )}
+                </TaskItem>
+              ))}
+            </TaskList>
+          )}
+        </Body>
+
+        <Footer>
+          <AddButton onClick={() => onAddTask(dateKey)}>
+            <Plus size={28} />
+            <AddText>Add Task</AddText>
+          </AddButton>
+        </Footer>
+      </Modal>
+    </Backdrop>
+  );
+}

--- a/frontend/src/components/Calendar/EditTaskModal.tsx
+++ b/frontend/src/components/Calendar/EditTaskModal.tsx
@@ -1,17 +1,26 @@
 import type { Priority, Task } from '@calendar/shared';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { Check } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+
+import { LABEL_COLORS, PRIORITY_VALUES } from '../../constants/taskMeta';
 
 interface EditTaskModalProps {
   task: Task | null;
   dateKey: string;
-  onSave: (data: { title: string; priority?: Priority; labels: string[] }, taskId?: string) => void;
+  onSave: (
+    data: {
+      title: string;
+      priority?: Priority;
+      labels: string[];
+      description?: string;
+      date?: string;
+    },
+    taskId?: string
+  ) => void;
   onClose: () => void;
 }
-
-const LABEL_COLORS = ['#34d399', '#f59e0b', '#8b5cf6', '#ec4899', '#06b6d4', '#ef4444'];
-const PRIORITIES: Priority[] = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'];
 
 const Backdrop = styled.div`
   position: fixed;
@@ -57,6 +66,26 @@ const Input = styled.input`
   font-size: ${({ theme }) => theme.font.size.md};
   outline: none;
   box-sizing: border-box;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.accent};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.colors.accent}33;
+  }
+`;
+
+const Textarea = styled.textarea`
+  width: 100%;
+  min-height: 92px;
+  padding: 10px 12px;
+  border: 1px solid ${({ theme }) => theme.colors.inputBorder};
+  border-radius: ${({ theme }) => theme.borderRadius};
+  background: ${({ theme }) => theme.colors.inputBg};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: ${({ theme }) => theme.font.size.md};
+  outline: none;
+  box-sizing: border-box;
+  resize: vertical;
+  font-family: inherit;
 
   &:focus {
     border-color: ${({ theme }) => theme.colors.accent};
@@ -110,6 +139,10 @@ const LabelSwatch = styled.button<{ swatchColor: string; selected: boolean }>`
   cursor: pointer;
   outline-offset: 2px;
   opacity: ${({ selected }) => (selected ? 1 : 0.5)};
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
     opacity 150ms ease,
     border-color 150ms ease,
@@ -118,6 +151,27 @@ const LabelSwatch = styled.button<{ swatchColor: string; selected: boolean }>`
   &:hover {
     opacity: 1;
   }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px ${({ theme }) => `${theme.colors.accent}33`};
+  }
+`;
+
+const CheckBadge = styled.span`
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;
+
+const CheckIcon = styled(Check)`
+  color: #ffffff;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
+  pointer-events: none;
 `;
 
 const Footer = styled.div`
@@ -174,6 +228,8 @@ export function EditTaskModal({ task, dateKey: _dateKey, onSave, onClose }: Edit
   const [title, setTitle] = useState(task?.title ?? '');
   const [priority, setPriority] = useState<Priority | undefined>(task?.priority ?? undefined);
   const [labels, setLabels] = useState<string[]>(task?.labels ?? []);
+  const [description, setDescription] = useState(task?.description ?? '');
+  const [date, setDate] = useState(task?.date ?? '');
 
   useEffect(() => {
     inputRef.current?.focus();
@@ -194,7 +250,16 @@ export function EditTaskModal({ task, dateKey: _dateKey, onSave, onClose }: Edit
   const handleSave = () => {
     const trimmed = title.trim();
     if (!trimmed) return;
-    onSave({ title: trimmed, priority, labels }, task?.id);
+    onSave(
+      {
+        title: trimmed,
+        priority,
+        labels,
+        description: description.trim() || undefined,
+        date: isEdit ? date : undefined,
+      },
+      task?.id
+    );
   };
 
   return (
@@ -213,11 +278,21 @@ export function EditTaskModal({ task, dateKey: _dateKey, onSave, onClose }: Edit
             if (e.key === 'Enter') handleSave();
           }}
         />
-
+        {isEdit && (
+          <Section>
+            <Label htmlFor="task-date">Date</Label>
+            <Input
+              id="task-date"
+              type="date"
+              value={date}
+              onChange={e => setDate(e.target.value)}
+            />
+          </Section>
+        )}
         <Section>
           <Label>Priority</Label>
           <PriorityRow>
-            {PRIORITIES.map(p => (
+            {PRIORITY_VALUES.map(p => (
               <PriorityButton
                 key={p}
                 active={priority === p}
@@ -240,11 +315,27 @@ export function EditTaskModal({ task, dateKey: _dateKey, onSave, onClose }: Edit
                 selected={labels.includes(color)}
                 onClick={() => toggleLabel(color)}
                 aria-label={`Toggle label ${color}`}
-              />
+                aria-pressed={labels.includes(color)}
+              >
+                {labels.includes(color) && (
+                  <CheckBadge>
+                    <CheckIcon size={14} strokeWidth={3} />
+                  </CheckBadge>
+                )}
+              </LabelSwatch>
             ))}
           </LabelsRow>
         </Section>
-
+        <Section>
+          <Label htmlFor="task-description">Description</Label>
+          <Textarea
+            id="task-description"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Add details..."
+            maxLength={1000}
+          />
+        </Section>
         <Footer>
           <CancelButton onClick={onClose}>Cancel</CancelButton>
           <SaveButton onClick={handleSave} disabled={!title.trim()}>

--- a/frontend/src/components/Calendar/TaskCard.tsx
+++ b/frontend/src/components/Calendar/TaskCard.tsx
@@ -30,21 +30,26 @@ const Card = styled.div<{ isDragging: boolean }>`
 `;
 
 const TopRow = styled.div`
+  min-width: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 4px;
   min-height: 20px;
 `;
 
 const Labels = styled.div`
+  min-width: 0;
   display: flex;
   gap: 4px;
+  flex: 1;
 `;
 
 const LabelBar = styled.div<{ color: string }>`
   height: 4px;
-  width: 32px;
+  flex: 1 1 0;
+  max-width: 32px;
+  min-width: 6px;
   border-radius: 2px;
   background: ${({ color }) => color};
 `;

--- a/frontend/src/components/ui/CustomSelect.tsx
+++ b/frontend/src/components/ui/CustomSelect.tsx
@@ -17,11 +17,15 @@ interface CustomSelectProps<T extends SelectValue> {
   size?: 'md' | 'lg';
   minWidth?: string;
   borderMode?: 'transparent' | 'light';
+  width?: string;
+  onMenuScroll?: (event: React.UIEvent<HTMLUListElement>) => void;
+  onMenuWheel?: (event: React.WheelEvent<HTMLUListElement>) => void;
 }
 
-const Wrap = styled.div<{ minWidth?: string }>`
+const Wrap = styled.div<{ minWidth?: string; width?: string }>`
   position: relative;
   min-width: ${({ minWidth }) => minWidth ?? '180px'};
+  width: ${({ width }) => width ?? 'auto'};
 `;
 
 const Trigger = styled.button<{
@@ -67,6 +71,7 @@ const Trigger = styled.button<{
 `;
 
 const Label = styled.span`
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -117,7 +122,10 @@ export function CustomSelect<T extends SelectValue>({
   ariaLabel,
   size = 'md',
   minWidth,
+  width,
   borderMode = 'light',
+  onMenuScroll,
+  onMenuWheel,
 }: CustomSelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -142,7 +150,7 @@ export function CustomSelect<T extends SelectValue>({
   }, [isOpen]);
 
   return (
-    <Wrap ref={rootRef} minWidth={minWidth}>
+    <Wrap ref={rootRef} minWidth={minWidth} width={width}>
       <Trigger
         type="button"
         size={size}
@@ -158,7 +166,7 @@ export function CustomSelect<T extends SelectValue>({
       </Trigger>
 
       {isOpen && (
-        <Menu role="listbox" aria-label={ariaLabel}>
+        <Menu role="listbox" aria-label={ariaLabel} onScroll={onMenuScroll} onWheel={onMenuWheel}>
           {options.map(option => (
             <li key={String(option.value)}>
               <OptionButton

--- a/frontend/src/constants/taskMeta.ts
+++ b/frontend/src/constants/taskMeta.ts
@@ -1,0 +1,11 @@
+import type { Priority } from '@calendar/shared';
+
+export const LABEL_COLORS = [
+  '#34d399',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#ef4444',
+] as const;
+export const PRIORITY_VALUES: Priority[] = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'];

--- a/frontend/src/hooks/useCountries.ts
+++ b/frontend/src/hooks/useCountries.ts
@@ -2,16 +2,39 @@ import { useEffect, useState } from 'react';
 
 import { type Country, fetchAvailableCountries } from '../services/holidayService';
 
+const COUNTRY_STORAGE_KEY = 'calendar-country';
+
 export function useCountries() {
   const [countries, setCountries] = useState<Country[]>([]);
-  const [country, setCountry] = useState('US');
+  const [country, setCountry] = useState(() => {
+    try {
+      return localStorage.getItem(COUNTRY_STORAGE_KEY) ?? 'US';
+    } catch {
+      return 'US';
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(COUNTRY_STORAGE_KEY, country);
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn('Country persistence failed', error);
+      }
+    }
+  }, [country]);
 
   useEffect(() => {
     let cancelled = false;
 
     fetchAvailableCountries()
       .then(data => {
-        if (!cancelled) setCountries(data);
+        if (!cancelled) {
+          setCountries(data);
+          if (!data.some(c => c.countryCode === country)) {
+            setCountry('US');
+          }
+        }
       })
       .catch(() => {
         if (!cancelled) {
@@ -22,7 +45,7 @@ export function useCountries() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [country]);
 
   return { countries, country, setCountry };
 }

--- a/frontend/src/store/tasksSlice.ts
+++ b/frontend/src/store/tasksSlice.ts
@@ -17,10 +17,28 @@ const initialState: TasksState = {
   error: null,
 };
 
-export const fetchTasksByMonthYear = createAsyncThunk('tasks/fetchTasks', async (month: string) => {
-  const { data } = await api.get<Task[]>('/tasks', { params: { month } });
-  return data;
-});
+export const fetchTasksByMonths = createAsyncThunk(
+  'tasks/fetchTasksByMonths',
+  async (months: string[]) => {
+    const uniqueMonths = Array.from(new Set(months));
+
+    const responses = await Promise.all(
+      uniqueMonths.map(month => api.get<Task[]>('/tasks', { params: { month } }))
+    );
+
+    const merged = new Map<string, Task>();
+    for (const response of responses) {
+      for (const task of response.data) {
+        merged.set(task.id, task);
+      }
+    }
+
+    return Array.from(merged.values()).sort((a, b) => {
+      if (a.date === b.date) return a.order - b.order;
+      return a.date.localeCompare(b.date);
+    });
+  }
+);
 
 export const fetchAllTasks = createAsyncThunk('tasks/fetchAllTasks', async () => {
   const { data } = await api.get<Task[]>('/tasks');
@@ -66,18 +84,6 @@ const tasksSlice = createSlice({
   },
   extraReducers: builder => {
     builder
-      .addCase(fetchTasksByMonthYear.pending, state => {
-        state.loading = true;
-        state.error = null;
-      })
-      .addCase(fetchTasksByMonthYear.fulfilled, (state, action) => {
-        state.loading = false;
-        state.tasks = action.payload;
-      })
-      .addCase(fetchTasksByMonthYear.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.error.message ?? 'Failed to fetch tasks';
-      })
       .addCase(createTask.fulfilled, (state, action) => {
         state.tasks.push(action.payload);
       })
@@ -103,6 +109,18 @@ const tasksSlice = createSlice({
         state.allTasks = action.payload;
       })
       .addCase(fetchAllTasks.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message ?? 'Failed to fetch tasks';
+      })
+      .addCase(fetchTasksByMonths.pending, state => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchTasksByMonths.fulfilled, (state, action) => {
+        state.loading = false;
+        state.tasks = action.payload;
+      })
+      .addCase(fetchTasksByMonths.rejected, (state, action) => {
         state.loading = false;
         state.error = action.error.message ?? 'Failed to fetch tasks';
       });

--- a/frontend/src/styles/GlobalStyles.tsx
+++ b/frontend/src/styles/GlobalStyles.tsx
@@ -6,8 +6,20 @@ export function GlobalStyles() {
   return (
     <Global
       styles={css`
+        html {
+          box-sizing: border-box;
+          -webkit-text-size-adjust: 100%;
+        }
+
+        *,
+        *::before,
+        *::after {
+          box-sizing: inherit;
+        }
+
         body {
           margin: 0;
+          min-height: 100vh;
           background-color: ${theme.colors.background};
           font-family: ${theme.font.family};
           color: ${theme.colors.text};
@@ -16,6 +28,22 @@ export function GlobalStyles() {
             color 200ms ease,
             border-color 200ms ease,
             box-shadow 200ms ease;
+        }
+
+        img,
+        picture,
+        video,
+        canvas,
+        svg {
+          display: block;
+          max-width: 100%;
+        }
+
+        input,
+        button,
+        textarea,
+        select {
+          font: inherit;
         }
 
         *,


### PR DESCRIPTION
## Summary

- Completes feature-level UX for calendar interactions across active and boundary days
- Improves search behavior and navigation feedback with day highlight and auto-scroll
- Adds full task edit metadata support (`description`, editable `date` in edit mode)
- Persists user preferences (`theme`, selected holiday country) across reloads

## Changes

- `frontend/src/components/Calendar/Calendar.tsx`
  - switches to multi-month task loading (`prev/current/next`)
  - adds search-result day highlight and auto-scroll
- `frontend/src/store/tasksSlice.ts`
  - adds `fetchTasksByMonths`
  - removes reliance on obsolete single-month fetch path
- `frontend/src/components/Calendar/DayCell.tsx`
  - enables full interactions in boundary cells
  - makes `+N more` actionable
- `frontend/src/components/Calendar/DayTasksModal.tsx`
  - supports add/edit/delete from full day task list
- `frontend/src/components/Calendar/EditTaskModal.tsx`
  - adds `description` field
  - adds editable `date` in edit mode
- `frontend/src/components/Calendar/TaskCard.tsx`
  - fixes top row layout so labels do not hide action controls
- `frontend/src/components/Calendar/CalendarHeader.tsx`
  - improves search close/clear behavior (outside click, blur, Escape)
  - improves "Today" behavior and header control UX
- `frontend/src/components/ui/CustomSelect.tsx`
  - adds menu scroll hooks for incremental year-list loading
- `frontend/src/constants/taskMeta.ts`
  - centralizes label and priority constants
- `frontend/src/hooks/useCountries.ts`, `frontend/src/App.tsx`
  - persist country/theme in localStorage
- `frontend/src/styles/GlobalStyles.tsx`
  - adds global base reset improvements

## Test Plan

- [ ] Search closes and clears on outside click, page blur, and Escape
- [ ] Search result click navigates to month/year and highlights target day
- [ ] Highlighted day auto-scrolls into viewport when off-screen
- [ ] Boundary cells support Add/Edit/Delete/DnD interactions
- [ ] Edit modal saves `description` and updated `date` correctly
- [ ] Tasks render correctly for boundary days from neighboring months
- [ ] Theme and selected country persist after browser refresh
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes

Closes #20 