### PR TITLE
fix(backend): keep helmet enabled but disable CSP to restore Swagger UI assets loading

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,7 +9,11 @@ import { setupSwagger } from './swagger';
 const app = express();
 app.set('trust proxy', 1);
 
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  })
+);
 app.use(corsMiddleware);
 app.use(express.json({ limit: '100kb' }));
 


### PR DESCRIPTION
fix(backend): keep helmet enabled but disable CSP to restore Swagger UI assets loading


